### PR TITLE
fix: requestid.Get will get null when the request header didn't take a Request ID

### DIFF
--- a/requestid.go
+++ b/requestid.go
@@ -97,5 +97,5 @@ type config struct {
 
 // Get returns the request identifier
 func Get(c *app.RequestContext) string {
-	return string(c.GetHeader(headerXRequestID))
+	return c.Response.Header.Get(headerXRequestID)
 }

--- a/requestid_test.go
+++ b/requestid_test.go
@@ -111,13 +111,14 @@ func TestRequestIDWithHandler(t *testing.T) {
 
 func TestGetRequestID(t *testing.T) {
 	r := route.NewEngine(hzconfig.NewOptions([]hzconfig.Option{}))
-	r.Use(New())
+	r.Use(New(
+		WithGenerator(func() string {
+			return testXRequestID
+		}),
+	))
 	r.GET("/", func(ctx context.Context, c *app.RequestContext) {
 		assert.DeepEqual(t, testXRequestID, Get(c))
 	})
 
-	_ = ut.PerformRequest(r, http.MethodGet, "/", nil, ut.Header{
-		Key:   "X-Request-ID",
-		Value: testXRequestID,
-	})
+	_ = ut.PerformRequest(r, http.MethodGet, "/", nil)
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix `requestid.Get` will get null when the request header didn't take a Request ID
zh: 修复`requestid.Get`在请求头中未携带Request ID时获取的值为空的问题

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes(https://github.com/hertz-contrib/requestid/issues/3)